### PR TITLE
Add support for :layout key in routers

### DIFF
--- a/.clj-kondo/imports/nubank/matcher-combinators/config.edn
+++ b/.clj-kondo/imports/nubank/matcher-combinators/config.edn
@@ -1,0 +1,4 @@
+{:linters
+ {:unresolved-symbol
+  {:exclude [(cljs.test/is [match? thrown-match?])
+             (clojure.test/is [match? thrown-match?])]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,7 @@
                                                                    "2.2.214"}
                              lambdaisland/kaocha        {:mvn/version
                                                          "1.91.1392"}
+                             nubank/matcher-combinators {:mvn/version "3.9.2"}
                              vvvvalvalval/scope-capture {:mvn/version "0.3.3"}}
                :extra-paths ["test"]
                :jvm-opts    ["--add-opens=java.base/java.nio=ALL-UNNAMED"

--- a/src/tram/http/interceptors.clj
+++ b/src/tram/http/interceptors.clj
@@ -92,7 +92,6 @@
 (def render-template-interceptor
   {:name  ::template-renderer
    :leave (fn [ctx]
-            (prn "rendering template interceptor")
             (cond
               (or (some? (get-in ctx [:response :body]))
                   (str/starts-with? (get-in ctx [:request :uri]) "/assets")

--- a/test/test_app/handlers/authentication_handlers.clj
+++ b/test/test_app/handlers/authentication_handlers.clj
@@ -1,6 +1,7 @@
 (ns test-app.handlers.authentication-handlers
   (:require [reitit.core]
             [reitit.http :refer [router]]
+            [test-app.views.authentication-views :as view]
             [tram.core]))
 
 (defn sign-in [req]
@@ -10,7 +11,9 @@
   {:status 200})
 
 (tram.core/defroutes routes
-  [["/sign-in"
+  [""
+   {:layout view/layout}
+   ["/sign-in"
     {:get  sign-in
      :name :route/sign-in}]
    ["/forgot-password"

--- a/test/test_app/handlers/authentication_handlers.clj
+++ b/test/test_app/handlers/authentication_handlers.clj
@@ -17,9 +17,11 @@
     {:get  sign-in
      :name :route/sign-in}]
    ["/forgot-password"
-    {:get  :view/forgot-password
-     :name :route/forgot-password
-     :post forgot}]
+    {:get          :view/forgot-password
+     :interceptors [{:name  :identity
+                     :enter identity}]
+     :name         :route/forgot-password
+     :post         forgot}]
    ["/healthcheck"
     {:post (constantly {:status 200})
      :get  (fn [_] {:status 200})

--- a/test/test_app/views/authentication_views.clj
+++ b/test/test_app/views/authentication_views.clj
@@ -1,5 +1,8 @@
 (ns test-app.views.authentication-views)
 
+(defn layout [children]
+  [:div#layout children])
+
 (defn sign-in [ctx]
   "hello, sign in")
 

--- a/test/tram/http/interceptors_test.clj
+++ b/test/tram/http/interceptors_test.clj
@@ -1,19 +1,18 @@
 (ns tram.http.interceptors-test
-  (:require [expectations.clojure.test :as e]
+  (:require [clojure.test :as t]
             [reitit.core :as r]
             [tram.http.interceptors :as sut]
             [tram.test-fixtures :refer [sample-router]]))
 
-(def expander
-  (:leave sut/expand-hiccup-interceptor))
+(t/deftest expanding-hiccup
+  (let [expander (:leave sut/expand-hiccup-interceptor)]
+    (t/is (match? {:response {:body [:a {:href "/dashboard"}]}}
+                  (expander {:request  {::r/router sample-router}
+                             :response {:body [:a {:href
+                                                   :route/dashboard}]}})))))
 
-(e/defexpect
-  expanding-hiccup
-  (e/expect [:a {:href "/dashboard"}]
-            (-> (expander {:request  {::r/router sample-router}
-                           :response {:body [:a {:href :route/dashboard}]}})
-                :response
-                :body)))
-
-(e/defexpect layout-interceptor
-  (e/expect 1 1))
+(t/deftest layout-interceptor
+  (let [layout-fn (fn [children] [:div#layout children])
+        ctx       (apply (:enter (sut/layout-interceptor layout-fn)) [{}])]
+    (t/is (match? {:layouts [layout-fn]} ctx)
+          "Layout interceptor did not add layout-fn to :layouts key.")))

--- a/test/tram/http/router_test.clj
+++ b/test/tram/http/router_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.zip :as zip]
             [expectations.clojure.test :as e]
             [test-app.handlers.authentication-handlers :refer [routes] :as auth]
-            [test-app.views.authentication-views]
+            [test-app.views.authentication-views :as views]
             [tram.http.router :as sut]))
 
 (defn get-spec-from-routes [routes route-uri]
@@ -18,7 +18,12 @@
                :get       {:handler     auth/sign-in
                            :handler-var #'auth/sign-in}
                :namespace "test-app.handlers.authentication-handlers"}
-              (e/in sign-in-route-data))))
+              (e/in sign-in-route-data)))
+
+  (let [global-route-data (get-spec-from-routes routes "")]
+    (e/expect some? (:interceptors global-route-data))
+    (e/expect {:layouts [#'test-app.views.authentication-views/layout]}
+              ((:enter (first (:interceptors global-route-data))) {}))))
 
 (e/defexpect expand-handler-entries
   ;; trivial case

--- a/test/tram/kaocha_hooks.clj
+++ b/test/tram/kaocha_hooks.clj
@@ -1,0 +1,9 @@
+(ns tram.kaocha-hooks
+  (:require [matcher-combinators.test]))
+
+(defn load-matcher-combinators
+  "Presently this only returns the test because requiring
+  `matcher-combinators.test` is done globally, but the kaocha hook requires a
+  fn."
+  [test test-plan]
+  test)

--- a/tests.edn
+++ b/tests.edn
@@ -1,3 +1,5 @@
-#kaocha/v1 {:tests [{:id          :unit
-                     :test-paths  ["test"]
-                     :ns-patterns [".*"]}]}
+#kaocha/v1 {:tests   [{:id          :unit
+                       :test-paths  ["test"]
+                       :ns-patterns [".*"]}]
+            :plugins [:kaocha.plugin/hooks]
+            :kaocha.hooks/pre-test [tram.kaocha-hooks/load-matcher-combinators]}


### PR DESCRIPTION
This allows a tram router to use a `:layout` key that can either be a layout-fn, or a keyword that references a layout fn in the corresponding view ns (something like `:view/layout-a`). 

I like the concept, but this needs more work because I want adding a key that changes behavior into the router (likely via interceptors) to feel first class. This is bespoke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added layout support to the HTTP router so routes can declare a layout that wraps their views; layouts resolve across namespaces.
- Tests
  - Expanded router tests to validate layout interceptor wiring; updated test app routes and views to exercise layouts.
- Chores
  - Removed a debugging print from an interceptor for cleaner logs.
- Refactor
  - Improved error handling to surface clearer failures for invalid handler entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->